### PR TITLE
Refactor search dialog to a searchbar like in browsers and text editors

### DIFF
--- a/OpenUtau/Controls/SearchBar.axaml
+++ b/OpenUtau/Controls/SearchBar.axaml
@@ -1,0 +1,79 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:OpenUtau.App.ViewModels"
+             x:Class="OpenUtau.App.Controls.SearchBar" Focusable="False">
+  <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="114,54,28,28,28,28" Width="280" Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
+    <!--Row 1-->
+    <TextBox Name="box" Grid.Row="0" Padding="4,3" Margin="0" Height="24" VerticalAlignment="Center" HorizontalAlignment="Stretch"
+             Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+             Text="{Binding SearchWord}" Focusable="True" Watermark="{DynamicResource pianoroll.menu.searchnote}"
+             GotFocus="Box_GotFocus"  KeyDown="Box_KeyDown"/>
+    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ResultCount}" Width="54" VerticalAlignment="Center" TextAlignment="Center"/>
+    <Button Grid.Row="0" Grid.Column="2" Command="{Binding SelectCommand}" CommandParameter="prev"
+      ToolTip.Tip="{DynamicResource pianoroll.menu.searchnote.prev}"
+      Width="24" Height="24" Margin="2,2,2,2"
+      Background="Transparent" BorderThickness="0">
+      <!-- icon source: https://github.com/microsoft/vscode-icons/blob/main/icons/light/arrow-left.svg -->
+      <Path  Classes="clear" Width="16" Height="16" HorizontalAlignment="Center" VerticalAlignment="Center"
+            Data="M7.00024 3.0929L2.00024 8.09288L2.00024 8.79999L7.00024 13.8L7.70734 13.0929L3.56091 8.94644L14.0002 8.94644L14.0002 7.94644L3.56091 7.94644L7.70734 3.8L7.00024 3.0929Z"
+            Fill="{StaticResource NeutralAccentBrush}">
+        <Path.RenderTransform>
+          <TransformGroup>
+            <ScaleTransform ScaleX=".75" ScaleY=".75"/>
+            <TranslateTransform X="0" Y="1"/>
+          </TransformGroup>
+        </Path.RenderTransform>
+      </Path>
+    </Button>
+    <Button Grid.Row="0" Grid.Column="3" Command="{Binding SelectCommand}" CommandParameter="next"
+      ToolTip.Tip="{DynamicResource pianoroll.menu.searchnote.next}"
+      Width="24" Height="24" Margin="2,2,2,2"
+      Background="Transparent" BorderThickness="0">
+      <!-- icon source: https://github.com/microsoft/vscode-icons/blob/main/icons/light/arrow-right.svg -->
+      <Path  Classes="clear" Width="16" Height="16" HorizontalAlignment="Center" VerticalAlignment="Center"
+            Data="M9.00025 13.8871L14.0002 8.8871L14.0002 8.17999L9.00025 3.17999L8.29314 3.8871L12.4396 8.03354L2.00024 8.03354L2.00024 9.03354L12.4396 9.03354L8.29314 13.18L9.00025 13.8871Z"
+            Fill="{StaticResource NeutralAccentBrush}">
+        <Path.RenderTransform>
+          <TransformGroup>
+            <ScaleTransform ScaleX=".75" ScaleY=".75"/>
+            <TranslateTransform X="0" Y="1"/>
+          </TransformGroup>
+        </Path.RenderTransform>
+      </Path>
+    </Button>
+    <Button Grid.Row="0" Grid.Column="4" Command="{Binding SelectCommand}"  CommandParameter="all"
+      ToolTip.Tip="{DynamicResource pianoroll.menu.searchnote.all}"
+      Width="24" Height="24" Margin="2,2,2,2"
+      Background="Transparent" BorderThickness="0">
+      <!-- icon source: https://github.com/microsoft/vscode-icons/blob/main/icons/light/new-folder.svg -->
+      <Path  Classes="clear" Width="16" Height="16" HorizontalAlignment="Center" VerticalAlignment="Center"
+            Data="M7.00024 3H4.00024V0H3.00024V3H0.000244141V4H3.00024V7H4.00024V4H7.00024V3ZM5.50024 7H5.00024V6H5.30024L6.10024 5.1L6.50024 5H14.0002V4H8.00024V3H14.5002L15.0002 3.5V13.5L14.5002 14H1.50024L1.00024 13.5V6.5V6V5H2.00024V6V6.5V13H14.0002V7V6H6.70024L5.90024 6.9L5.50024 7Z"
+            Fill="{StaticResource NeutralAccentBrush}">
+        <Path.RenderTransform>
+          <TransformGroup>
+            <ScaleTransform ScaleX=".75" ScaleY=".75"/>
+            <TranslateTransform X="0" Y="1"/>
+          </TransformGroup>
+        </Path.RenderTransform>
+      </Path>
+    </Button>
+    <Button Grid.Row="0" Grid.Column="5" Click="OnClose"
+      ToolTip.Tip="{DynamicResource pianoroll.menu.searchnote.close}"
+      Width="24" Height="24" Margin="2,2,2,2"
+      Background="Transparent" BorderThickness="0">
+      <!-- icon source: https://github.com/microsoft/vscode-icons/blob/main/icons/light/close.svg -->
+      <Path  Classes="clear" Width="16" Height="16" HorizontalAlignment="Center" VerticalAlignment="Center"
+            Data="M8.00028 8.70711L11.6467 12.3536L12.3538 11.6465L8.70739 8.00001L12.3538 4.35356L11.6467 3.64645L8.00028 7.2929L4.35384 3.64645L3.64673 4.35356L7.29317 8.00001L3.64673 11.6465L4.35384 12.3536L8.00028 8.70711Z"
+            Fill="{StaticResource NeutralAccentBrush}">
+        <Path.RenderTransform>
+          <TransformGroup>
+            <ScaleTransform ScaleX=".75" ScaleY=".75"/>
+            <TranslateTransform X="0" Y="1"/>
+          </TransformGroup>
+        </Path.RenderTransform>
+      </Path>
+    </Button>
+  </Grid>
+</UserControl>

--- a/OpenUtau/Controls/SearchBar.axaml.cs
+++ b/OpenUtau/Controls/SearchBar.axaml.cs
@@ -1,0 +1,83 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using OpenUtau.App.ViewModels;
+using OpenUtau.Core.Ustx;
+
+namespace OpenUtau.App.Controls {
+    public partial class SearchBar : UserControl {
+        SearchNoteViewModel? viewModel;
+        private DispatcherTimer? focusTimer;
+
+        public SearchBar() {
+            InitializeComponent();
+            IsVisible = false;
+        }
+
+        public void Show(NotesViewModel notesViewModel) {
+            viewModel = new SearchNoteViewModel(notesViewModel);
+            DataContext = viewModel;
+            //If there is a note selected, use its lyric as the search word
+            if (notesViewModel.Part != null && notesViewModel.Part.notes.Count > 0) {
+                if (notesViewModel.Selection.Count > 0) {
+                    if (notesViewModel.Selection.FirstOrDefault() is UNote note) {
+                        if (!string.IsNullOrEmpty(note.lyric)) {
+                            (viewModel).SearchWord = note.lyric;
+                        }
+                    }
+                }
+            }
+            IsVisible = true;
+            box.SelectAll();
+            focusTimer = new DispatcherTimer(
+                TimeSpan.FromMilliseconds(15),
+                DispatcherPriority.Normal,
+                FocusTimer_Tick);
+            focusTimer.Start();
+        }
+
+        private void FocusTimer_Tick(object? sender, System.EventArgs e) {
+            box.Focus();
+            if (focusTimer != null) {
+                focusTimer.Tick -= FocusTimer_Tick;
+                focusTimer.Stop();
+                focusTimer = null;
+            }
+        }
+
+        public void OnClose(object sender, RoutedEventArgs args) {
+            IsVisible = false;
+        }
+
+        private void Box_GotFocus(object? sender, GotFocusEventArgs e) {
+            box.SelectAll();
+        }
+
+        private void Box_KeyDown(object? sender, KeyEventArgs e){
+            if(!IsVisible){
+                return;
+            }
+            bool isShift = e.KeyModifiers == KeyModifiers.Shift;
+            switch (e.Key){
+                case Key.Enter:
+                    if (DataContext is SearchNoteViewModel viewModel){
+                        if(isShift){
+                            viewModel.Prev();
+                        }else{
+                            viewModel.Next();
+                        }
+                    }
+                    e.Handled = true;
+                    break;
+                case Key.Escape:
+                    IsVisible = false;
+                    e.Handled = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -227,6 +227,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="pianoroll.menu.part.singer">Singer and Oto settings</system:String>
   <system:String x:Key="pianoroll.menu.searchnote">Search Note</system:String>
   <system:String x:Key="pianoroll.menu.searchnote.all">Select All</system:String>
+  <system:String x:Key="pianoroll.menu.searchnote.close">Close</system:String>
   <system:String x:Key="pianoroll.menu.searchnote.next">Next</system:String>
   <system:String x:Key="pianoroll.menu.searchnote.prev">Prev</system:String>
   <system:String x:Key="pianoroll.toggle.finalpitch">View Final Pitch to Render (R)</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -215,6 +215,11 @@
   <system:String x:Key="pianoroll.menu.notes.removetailrest">删除尾部"R"音符</system:String>
   <system:String x:Key="pianoroll.menu.part">片段</system:String>
   <system:String x:Key="pianoroll.menu.part.legacypluginexp">传统插件 (实验性)</system:String>
+  <system:String x:Key="pianoroll.menu.searchnote">查找音符</system:String>
+  <system:String x:Key="pianoroll.menu.searchnote.all">全选</system:String>
+  <system:String x:Key="pianoroll.menu.searchnote.close">关闭</system:String>
+  <system:String x:Key="pianoroll.menu.searchnote.next">下一个</system:String>
+  <system:String x:Key="pianoroll.menu.searchnote.prev">上一个</system:String>
   <system:String x:Key="pianoroll.toggle.finalpitch">显示最终音高线 (R)</system:String>
   <!--<system:String x:Key="pianoroll.toggle.noteparams">View Note Parameters (\)</system:String>-->
   <system:String x:Key="pianoroll.toggle.phoneme">显示音素 (O)</system:String>

--- a/OpenUtau/ViewModels/SearchNoteViewModel.cs
+++ b/OpenUtau/ViewModels/SearchNoteViewModel.cs
@@ -16,6 +16,7 @@ namespace OpenUtau.App.ViewModels {
         NotesViewModel notesViewModel { get; }
         List<UNote> notes = new List<UNote>();
         int selection = -1;
+        [Reactive]public string ResultCount { get; private set; } = "";
         static string searchWord = "";
 
         public SearchNoteViewModel(NotesViewModel notesViewModel) {
@@ -50,6 +51,7 @@ namespace OpenUtau.App.ViewModels {
                 Count = 0;
             }
             selection = -1;
+            UpdateResult();
         }
 
         public void Prev() {
@@ -69,6 +71,7 @@ namespace OpenUtau.App.ViewModels {
                     DocManager.Inst.ExecuteCmd(new FocusNoteNotification(notesViewModel.Part, note));
                 }
             }
+            UpdateResult();
         }
 
         public void Next() {
@@ -88,6 +91,7 @@ namespace OpenUtau.App.ViewModels {
                     DocManager.Inst.ExecuteCmd(new FocusNoteNotification(notesViewModel.Part, note));
                 }
             }
+            UpdateResult();
         }
 
         public void SelectAll() {
@@ -96,6 +100,14 @@ namespace OpenUtau.App.ViewModels {
                 notesViewModel.Selection.Add(note);
             }
             MessageBus.Current.SendMessage(new NotesSelectionEvent(notesViewModel.Selection));
+        }
+
+        public void UpdateResult(){
+            if (selection >= 0) {
+                ResultCount = $"{selection + 1}/{Count}";
+            }else{
+                ResultCount = $"{Count}";
+            }
         }
 
         public void OnClose() {

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -407,6 +407,12 @@
           </Border>
         </Border>
       </StackPanel>
+      <StackPanel Grid.Row="2" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Top"
+                  Margin="0,12,12,0" Orientation="Horizontal">
+        <Border CornerRadius="2" BoxShadow="0 0 5 1 #1F000000">
+          <c:SearchBar Name="SearchBar"/>
+        </Border>
+      </StackPanel>
       <Rectangle Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
                  Margin="0,0,0,60" Height="6" Opacity="0.15" IsVisible="{Binding NotesViewModel.ShowPhoneme}">
         <Rectangle.Fill>

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -90,11 +90,7 @@ namespace OpenUtau.App.Views {
             if (ViewModel.NotesViewModel.Part == null || ViewModel.NotesViewModel.Part.notes.Count == 0) {
                 return;
             }
-            var vm = new SearchNoteViewModel(ViewModel.NotesViewModel);
-            var dialog = new SearchNoteDialog() {
-                DataContext = vm,
-            };
-            dialog.ShowDialog(this);
+            SearchBar.Show(ViewModel.NotesViewModel);
         }
 
         void ReplaceLyrics() {
@@ -805,6 +801,10 @@ namespace OpenUtau.App.Views {
 
         void OnKeyDown(object sender, KeyEventArgs args) {
             if (LyricBox != null && LyricBox.IsVisible) {
+                args.Handled = false;
+                return;
+            }
+            if (SearchBar != null && SearchBar.IsVisible && SearchBar.box.IsFocused) {
                 args.Handled = false;
                 return;
             }


### PR DESCRIPTION
- Refactor search dialog to a searchbar, like in browsers and text editors
- Add Key bindings: Enter for navigating to the next match, Shift+Enter for navigating to the previous match, and ESC to exit searchbar.
- If the user selected a note before opening the search dialog, use the lyric of the selection as the search word.
- Show both the count of matches and the index of current match.

<img width="960" alt="image" src="https://github.com/maiko3tattun/OpenUtau/assets/54425948/ec5d155f-709a-42ba-b32b-d9ed51c4e74a">
